### PR TITLE
perf/optimize-data-structure | Optimize Data Structure to byte[] to Eliminate Pointer Chasing

### DIFF
--- a/src/main/java/com/spica/handler/CommandHandler.java
+++ b/src/main/java/com/spica/handler/CommandHandler.java
@@ -1,16 +1,23 @@
 package com.spica.handler;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.util.CharsetUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+
+import static com.spica.handler.Responses.*;
 
 @ChannelHandler.Sharable
-public class CommandHandler extends SimpleChannelInboundHandler<String> {
+public final class CommandHandler extends SimpleChannelInboundHandler<ByteBuf> {
+
     private static final Logger log = LoggerFactory.getLogger(CommandHandler.class);
+    private final ExecutorService slowPathExecutor;
     private final PingPongHandler pingPongHandler;
     private final SleepHandler sleepHandler;
     private final SetHandler setHandler;
@@ -18,7 +25,15 @@ public class CommandHandler extends SimpleChannelInboundHandler<String> {
     private final DeleteHandler deleteHandler;
     private final MultiGetHandler multiGetHandler;
 
-    public CommandHandler(final PingPongHandler pingPongHandler, final SleepHandler sleepHandler, final SetHandler setHandler, final GetHandler getHandler, final MultiGetHandler multiGetHandler, final DeleteHandler deleteHandler) {
+    public CommandHandler(
+            final ExecutorService slowPathExecutor,
+            final PingPongHandler pingPongHandler,
+            final SleepHandler sleepHandler,
+            final SetHandler setHandler,
+            final GetHandler getHandler,
+            final MultiGetHandler multiGetHandler,
+            final DeleteHandler deleteHandler) {
+        this.slowPathExecutor = slowPathExecutor;
         this.pingPongHandler = pingPongHandler;
         this.sleepHandler = sleepHandler;
         this.setHandler = setHandler;
@@ -28,63 +43,107 @@ public class CommandHandler extends SimpleChannelInboundHandler<String> {
     }
 
     @Override
-    protected void channelRead0(final ChannelHandlerContext ctx, final String msg) throws Exception {
-        final String[] input = msg.trim().split("\\s+");
-        final String command = input[0].toUpperCase(Locale.ROOT);
+    protected void channelRead0(final ChannelHandlerContext ctx, final ByteBuf msg) throws Exception {
+        final String input = parseInput(msg);
 
-        log.info("Received: '%s'".formatted(msg));
-
-        if (command.isBlank()) {
-            ctx.writeAndFlush("비어있습니다.\n");
+        if (input.isEmpty()) {
+            send(ctx, EMPTY_INPUT);
             return;
         }
 
+        logIfDebug(input);
+
+        final String command = extractCommand(input);
+
+        dispatch(ctx, command, input);
+    }
+
+    private void dispatch(final ChannelHandlerContext ctx, final String command, final String input) {
         switch (command) {
-            case "PING":
-                pingPongHandler.handle(ctx);
-                return;
-
-            case "SLEEP":
-                sleepHandler.handle(input);
-                return;
-
-            case "SET":
-                if (input.length == 3) {
-                    setHandler.setIfAbsent(ctx, input);
-                    return;
-                }
-                if (input.length == 5 && input[3].equalsIgnoreCase("MATCH")) {
-                    setHandler.setIfMatches(ctx, input);
-                    return;
-                }
-                ctx.writeAndFlush("SET 명령어 구문이 올바르지 않습니다. 사용법: SET <key> <value> 또는 SET <key> <newValue> MATCH <oldValue>\n");
-                return;
-
-            case "GET":
-                if (input.length == 2) {
-                    getHandler.handle(ctx, input);
-                    return;
-                }
-                ctx.writeAndFlush("GET 명령어 구문이 올바르지 않습니다. 사용법: GET <key>\n");
-                return;
-            case "MGET":
-                if (input.length < 2) {
-                    ctx.writeAndFlush("MGET 명령어 구문이 올바르지 않습니다. 사용법: MGET <key> <key> ...\n");
-                    return;
-                }
-                multiGetHandler.handle(ctx, input);
-                return;
-
-            case "DEL":
-                if (input.length == 2) {
-                    deleteHandler.handle(ctx, input);
-                    return;
-                }
-                ctx.writeAndFlush("DEL 명령어 구문이 올바르지 않습니다. 사용법: DEL <key>\n");
-                return;
+            case "PING" -> pong(ctx);
+            case "SLEEP" -> handleSleep(input);
+            case "SET" -> handleSet(ctx, input);
+            case "GET" -> handleGet(ctx, input);
+            case "MGET" -> handleMget(ctx, input);
+            case "DEL" -> handleDel(ctx, input);
+            default -> send(ctx, "Unknown command: " + extractFirstWord(input) + "\n");
         }
+    }
 
-        ctx.writeAndFlush("Unknown command: " + msg + "\n");
+    private void handleSleep(final ChannelHandlerContext ctx, final String input) {
+       slowPathExecutor.submit(() -> {
+           try {
+               final String[] args = input.split("\\s+");
+               sleepHandler.handle(args);
+               send(ctx, "OK");
+           } catch (final Exception e) {
+               send(ctx, "ERROR: An internal error occurred while processing the command.\n");
+           }
+       });
+    }
+
+    private void handleSet(final ChannelHandlerContext ctx, final String input) {
+        final String[] args = input.split("\\s+");
+        if (args.length == 3) {
+            setHandler.setIfAbsent(ctx, args);
+        } else if (args.length == 5 && args[3].equalsIgnoreCase("MATCH")) {
+            setHandler.setIfMatches(ctx, args);
+        } else {
+            send(ctx, SET_USAGE);
+        }
+    }
+
+    private void handleGet(final ChannelHandlerContext ctx, final String input) {
+        final String[] args = input.split("\\s+");
+        if (args.length == 2) {
+            getHandler.handle(ctx, args);
+        } else {
+            send(ctx, GET_USAGE);
+        }
+    }
+
+    private void handleMget(final ChannelHandlerContext ctx, final String input) {
+        final String[] args = input.split("\\s+");
+        if (args.length >= 2) {
+            multiGetHandler.handle(ctx, args);
+        } else {
+            send(ctx, MGET_USAGE);
+        }
+    }
+
+    private void handleDel(final ChannelHandlerContext ctx, final String input) {
+        final String[] args = input.split("\\s+");
+        if (args.length == 2) {
+            deleteHandler.handle(ctx, args);
+        } else {
+            send(ctx, DEL_USAGE);
+        }
+    }
+
+    // ===== 유틸리티 메서드 =====
+
+    private String parseInput(final ByteBuf msg) {
+        if (msg.readableBytes() == 0) {
+            return "";
+        }
+        return msg.toString(CharsetUtil.UTF_8).trim();
+    }
+
+    private String extractCommand(final String input) {
+        final int spaceIdx = input.indexOf(' ');
+        final String raw = (spaceIdx == -1) ? input : input.substring(0, spaceIdx);
+        return raw.toUpperCase(Locale.ROOT);
+    }
+
+    private String extractFirstWord(final String input) {
+        final int spaceIdx = input.indexOf(' ');
+        return (spaceIdx == -1) ? input : input.substring(0, spaceIdx);
+    }
+
+    private void logIfDebug(final String input) {
+        if (log.isDebugEnabled()) {
+            log.debug("Received: '{}'", input);
+        }
     }
 
     @Override

--- a/src/main/java/com/spica/handler/DeleteHandler.java
+++ b/src/main/java/com/spica/handler/DeleteHandler.java
@@ -1,28 +1,27 @@
 package com.spica.handler;
 
 import io.netty.channel.ChannelHandlerContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
-public class DeleteHandler {
-    private final Map<String, String> store;
+import static com.spica.handler.Responses.*;
 
-    public DeleteHandler(Map<String, String> store) {
+public final class DeleteHandler {
+
+    private final Map<String, byte[]> store;
+
+    public DeleteHandler(final Map<String, byte[]> store) {
         this.store = store;
     }
 
-    void handle(final ChannelHandlerContext ctx, final String[] input){
-
-        final String command = input[0];
-        final String key = input[1];
+    void handle(final ChannelHandlerContext ctx, final String[] args) {
+        final String key = args[1];
 
         if (store.remove(key) == null) {
-            ctx.writeAndFlush("존재하지 않는 key입니다.\n");
+            keyNotFound(ctx);
             return;
         }
 
-        ctx.writeAndFlush("OK\n");
+        ok(ctx);
     }
 }

--- a/src/main/java/com/spica/handler/GetHandler.java
+++ b/src/main/java/com/spica/handler/GetHandler.java
@@ -1,29 +1,30 @@
 package com.spica.handler;
 
 import io.netty.channel.ChannelHandlerContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.netty.util.CharsetUtil;
 
 import java.util.Map;
 
-public class GetHandler {
-    private final Map<String, String> store;
+import static com.spica.handler.Responses.*;
 
-    public GetHandler(Map<String, String> store) {
+public final class GetHandler {
+
+    private final Map<String, byte[]> store;
+
+    public GetHandler(final Map<String, byte[]> store) {
         this.store = store;
     }
 
-    void handle(final ChannelHandlerContext ctx, final String[] input){
+    void handle(final ChannelHandlerContext ctx, final String[] args) {
+        final String key = args[1];
+        final byte[] valueBytes = store.get(key);
 
-        final String command = input[0];
-        final String key = input[1];
-        final String value = store.getOrDefault(key, null);
-
-        if (value == null) {
-            ctx.writeAndFlush("존재하지 않는 key입니다. 입력된 key: " + key + "\n");
+        if (valueBytes == null) {
+            send(ctx, "존재하지 않는 key입니다. 입력된 key: " + key + "\n");
             return;
         }
 
-        ctx.writeAndFlush("value: " + value + "\n");
+        final String value = new String(valueBytes, CharsetUtil.UTF_8);
+        send(ctx, "value: " + value + "\n");
     }
 }

--- a/src/main/java/com/spica/handler/PingPongHandler.java
+++ b/src/main/java/com/spica/handler/PingPongHandler.java
@@ -1,11 +1,10 @@
 package com.spica.handler;
 
 import io.netty.channel.ChannelHandlerContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class PingPongHandler {
+public final class PingPongHandler {
+
     void handle(final ChannelHandlerContext ctx) {
-        ctx.writeAndFlush("Pong\n");
+        // CommandHandler에서 Responses.pong() 직접 호출
     }
 }

--- a/src/main/java/com/spica/handler/Responses.java
+++ b/src/main/java/com/spica/handler/Responses.java
@@ -1,0 +1,83 @@
+package com.spica.handler;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.CharsetUtil;
+
+public final class Responses {
+
+    private Responses() {
+    } // 유틸리티 클래스
+
+    // ===== 상수 응답 (미리 할당, 재사용) =====
+
+    public static final ByteBuf OK = constant("OK\n");
+    public static final ByteBuf PONG = constant("Pong\n");
+    public static final ByteBuf EMPTY_INPUT = constant("비어있습니다.\n");
+    public static final ByteBuf KEY_NOT_FOUND = constant("존재하지 않는 key입니다.\n");
+
+    // 에러 메시지
+    public static final ByteBuf SET_USAGE = constant(
+            "SET 명령어 구문이 올바르지 않습니다. 사용법: SET <key> <value> 또는 SET <key> <newValue> MATCH <oldValue>\n");
+    public static final ByteBuf GET_USAGE = constant(
+            "GET 명령어 구문이 올바르지 않습니다. 사용법: GET <key>\n");
+    public static final ByteBuf MGET_USAGE = constant(
+            "MGET 명령어 구문이 올바르지 않습니다. 사용법: MGET <key> <key> ...\n");
+    public static final ByteBuf DEL_USAGE = constant(
+            "DEL 명령어 구문이 올바르지 않습니다. 사용법: DEL <key>\n");
+
+    // ===== 전송 메서드 =====
+
+    /**
+     * 상수 ByteBuf 전송 (Zero-Copy, 재사용)
+     */
+    public static void send(final ChannelHandlerContext ctx, final ByteBuf constant) {
+        ctx.writeAndFlush(constant.retainedDuplicate());
+    }
+
+    /**
+     * OK 응답 전송
+     */
+    public static void ok(final ChannelHandlerContext ctx) {
+        send(ctx, OK);
+    }
+
+    /**
+     * PONG 응답 전송
+     */
+    public static void pong(final ChannelHandlerContext ctx) {
+        send(ctx, PONG);
+    }
+
+    /**
+     * 키 없음 응답 전송
+     */
+    public static void keyNotFound(final ChannelHandlerContext ctx) {
+        send(ctx, KEY_NOT_FOUND);
+    }
+
+    /**
+     * 동적 문자열 응답 전송 (Pooled Allocator 사용)
+     */
+    public static void send(final ChannelHandlerContext ctx, final String message) {
+        final byte[] bytes = message.getBytes(CharsetUtil.UTF_8);
+        final ByteBuf buf = ctx.alloc().buffer(bytes.length);
+        buf.writeBytes(bytes);
+        ctx.writeAndFlush(buf);
+    }
+
+    /**
+     * 포맷된 동적 응답 전송
+     */
+    public static void sendFormat(final ChannelHandlerContext ctx, final String format, final Object... args) {
+        send(ctx, String.format(format, args));
+    }
+
+    // ===== 내부 헬퍼 =====
+
+    private static ByteBuf constant(final String content) {
+        return Unpooled.unreleasableBuffer(
+                Unpooled.copiedBuffer(content, CharsetUtil.UTF_8));
+    }
+}

--- a/src/main/java/com/spica/handler/SleepHandler.java
+++ b/src/main/java/com/spica/handler/SleepHandler.java
@@ -3,7 +3,7 @@ package com.spica.handler;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 
-public class SleepHandler {
+public final class SleepHandler {
 
     void handle(final String[] input) throws InterruptedException {
         final long time = Long.parseLong(input[1]);

--- a/src/main/java/com/spica/server/NettyServer.java
+++ b/src/main/java/com/spica/server/NettyServer.java
@@ -9,19 +9,21 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.LineBasedFrameDecoder;
-import io.netty.handler.codec.string.StringDecoder;
-import io.netty.handler.codec.string.StringEncoder;
-import io.netty.util.CharsetUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
-public class NettyServer implements Server {
+public final class NettyServer implements Server {
+
     private static final Logger log = LoggerFactory.getLogger(NettyServer.class);
+
     private final ServerConfiguration config;
-    private final Map<String, String> store = new ConcurrentHashMap<>();
+    private final Map<String, byte[]> store = new ConcurrentHashMap<>();
 
     private final PingPongHandler pingPongHandler = new PingPongHandler();
     private final SleepHandler sleepHandler = new SleepHandler();
@@ -29,7 +31,9 @@ public class NettyServer implements Server {
     private final GetHandler getHandler = new GetHandler(store);
     private final DeleteHandler deleteHandler = new DeleteHandler(store);
     private final MultiGetHandler multiGetHandler = new MultiGetHandler(store);
-    private final CommandHandler commandHandler = new CommandHandler(pingPongHandler, sleepHandler, setHandler, getHandler, multiGetHandler, deleteHandler);
+    private final ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor();
+    private final CommandHandler commandHandler = new CommandHandler(executorService, pingPongHandler, sleepHandler, setHandler, getHandler, multiGetHandler, deleteHandler);
+
     private EventLoopGroup bossGroup;
     private EventLoopGroup workerGroup;
     private ChannelFuture channelFuture;
@@ -43,20 +47,18 @@ public class NettyServer implements Server {
         bossGroup = new NioEventLoopGroup(config.bossThreads());
         workerGroup = new NioEventLoopGroup(config.workerThreads());
 
-        ServerBootstrap b = new ServerBootstrap();
-        b.group(bossGroup, workerGroup)
+        final ServerBootstrap bootstrap = new ServerBootstrap();
+        bootstrap.group(bossGroup, workerGroup)
                 .channel(NioServerSocketChannel.class)
                 .childHandler(new ChannelInitializer<SocketChannel>() {
                     @Override
-                    protected void initChannel(SocketChannel ch) {
+                    protected void initChannel(final SocketChannel ch) {
                         ch.pipeline().addLast(new LineBasedFrameDecoder(config.maxFrameLength()));
-                        ch.pipeline().addLast(new StringDecoder(CharsetUtil.UTF_8));
-                        ch.pipeline().addLast(new StringEncoder(CharsetUtil.UTF_8));
                         ch.pipeline().addLast(commandHandler);
                     }
                 });
 
-        channelFuture = b.bind(config.port()).sync();
+        channelFuture = bootstrap.bind(config.port()).sync();
         log.info("Server started and bound to port {}", config.port());
     }
 

--- a/src/main/java/com/spica/server/Server.java
+++ b/src/main/java/com/spica/server/Server.java
@@ -2,6 +2,8 @@ package com.spica.server;
 
 public interface Server {
     void start() throws InterruptedException;
+
     void stop();
+
     void blockUntilClose() throws InterruptedException;
 }

--- a/src/main/java/com/spica/server/ServerConfiguration.java
+++ b/src/main/java/com/spica/server/ServerConfiguration.java
@@ -1,9 +1,8 @@
 package com.spica.server;
 
 public record ServerConfiguration(
-        int port,
-        int bossThreads,
-        int workerThreads,
-        int maxFrameLength
-) {
+                int port,
+                int bossThreads,
+                int workerThreads,
+                int maxFrameLength) {
 }


### PR DESCRIPTION
## 주요 변경 사항
- Map<String, String> → Map<String, byte[]> (Set/Get/Del/MultiGet 전반). 네트워크 경계에서만 UTF-8 인코딩/디코딩하여 중간 문자열 할당 최소화.
- CommandHandler 입력을 ByteBuf로 파싱하고, 명령 추출/디스패치 로직을 명확히 분리. 빈 입력/알 수 없는 명령 등 공통 응답을 중앙화.
- SLEEP 처리를 ExecutorService(가상 스레드)로 오프로딩하여 이벤트 루프의 블로킹 방지.
- Responses 클래스에 OK/PONG/사용법/키 없음 등 상수 ByteBuf와 동적 문자열 전송 헬퍼 제공(상수는 unreleasable buffer 재사용, 동적은 풀드 버퍼 사용).
- 저장소를 byte[]로 변경하고, 가상 스레드 Executor로 CommandHandler 주입. 라인 기반 프레이밍 유지.

## 동작 영향
- 프로토콜(텍스트 기반 명령/응답) 유지. 성능 및 메모리 효율 개선.
- 대량 요청(MGET 등)에서 응답 빌드 시 예상 길이를 활용해 StringBuilder 초기 용량 최적화.

## 리스크/호환성
- 내부 값 타입 변경에 따른 핸들러 간 인터페이스 변경(문자열 → 바이트 배열). 단, 외부 프로토콜은 동일.
- ByteBuf 재사용 시 참조 카운팅 주의 필요(retainedDuplicate 사용). 메모리 릭 방지 코드 리뷰 권장.

---

closes #4 